### PR TITLE
Fix error reported in "Unsyncing after idle" #28 

### DIFF
--- a/lib/connectors/connector.js
+++ b/lib/connectors/connector.js
@@ -15,7 +15,11 @@ export default class Connector {
 
     self.connection = connection;
     self.client = null;
-    self.debug = false;
+    if(atom.config.get('ftp-remote-edit.debug')){
+      self.debug = atom.config.get('ftp-remote-edit.debug');
+    }else{
+      self.debug = false;
+    }
 
     if (self.connection.sftp === true) {
       self.client = new sftpClient(self.connection);

--- a/lib/connectors/sftp.js
+++ b/lib/connectors/sftp.js
@@ -43,6 +43,8 @@ export default class Sftp {
     const self = this;
 
     if (!self.client) return false;
+    if (!self.client.sftp) return false;
+    if (!self.client.sftp._stream) return false;
     return self.client.sftp._stream.readable;
   }
 


### PR DESCRIPTION
Fix error reported in "Unsyncing after idle" #28 

TypeError: Cannot read property '_stream' of undefined at Sftp.isConnected ftp-remote-edit/lib/connectors/sftp.js:46:28

Added option to enable debug mode in atoms config.json:

"ftp-remote-edit":
  debug: true