### PR TITLE
Added feature request #106

### DIFF
--- a/lib/config/config-schema.json
+++ b/lib/config/config-schema.json
@@ -58,6 +58,13 @@
         "type": "boolean",
         "default": true,
         "order": 6
+      },
+      "sortServerProfilesByName": {
+        "title": "List Servers By Name",
+        "description": "When listing servers in the FTP-Remote-Edit view, list servers by name rather than by host.",
+        "type": "boolean",
+        "default": true,
+        "order": 7
       }
     },
     "order": 3

--- a/lib/views/tree-view.js
+++ b/lib/views/tree-view.js
@@ -111,6 +111,11 @@ class TreeView extends ScrollView {
         self.reload();
       }
     });
+    atom.config.onDidChange('ftp-remote-edit.tree.sortServerProfilesByName', () => {
+      if (self.isVisible()) {
+        self.reload();
+      }
+    });
     atom.config.onDidChange('ftp-remote-edit.tree.hideIgnoredNames', () => {
       self.ignoredPatterns = self.loadIgnoredPatterns();
       if (self.isVisible()) {
@@ -244,10 +249,16 @@ class TreeView extends ScrollView {
     let configHash = atom.config.get('ftp-remote-edit.config');
     if (configHash) {
       let config = decrypt(password, configHash);
+      let sortServerProfilesByName = atom.config.get('ftp-remote-edit.tree.sortServerProfilesByName');
       self.servers = JSON.parse(cleanJsonString(config));
       self.servers.sort(function (a, b) {
-        if (a.host < b.host) return -1;
-        if (a.host > b.host) return 1;
+        if (sortServerProfilesByName) {
+          if (a.name < b.name) return -1;
+          if (a.name > b.name) return 1;
+        } else {
+          if (a.host < b.host) return -1;
+          if (a.host > b.host) return 1;          
+        }
         return 0;
       });
     }


### PR DESCRIPTION
Added the option to list servers in the Ftp-Remote-Edit tree view by
name. Added a boolean option in the config panel that is true by
default. Servers will be listed by name if true and by host if false.