### PR TITLE
URI Handler for temporary server add

### DIFF
--- a/lib/ftp-remote-edit.js
+++ b/lib/ftp-remote-edit.js
@@ -30,10 +30,13 @@ class FtpRemoteEdit {
     self.treeView = null;
     self.protocolView = null;
     self.configurationView = null;
+    self.debug = false;
   }
 
   activate() {
     const self = this;
+
+    self.debug = atom.config.get('ftp-remote-edit.dev.debug');
 
     // Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     self.listeners = new CompositeDisposable();
@@ -84,6 +87,39 @@ class FtpRemoteEdit {
 
   serialize() {
     return {};
+  }
+
+  handleURI(parsedUri) {
+      const self = this;
+
+      var regex = /(\/)?([a-z0-9_\-]{1,5}:\/\/)(([a-z0-9_\-\s]{1,})((:([a-z0-9_\-\s]{1,}))?[\@\x40]))?([a-z0-9_\-.]+)(:([0-9]*))?/gi;
+      var is_matched = parsedUri.path.match(regex);
+
+      if(is_matched) {
+          var matched = regex.exec(parsedUri.path);
+
+          var protocol = matched[2];
+          var username = matched[4];
+          var password = matched[7];
+          var host = matched[8];
+          var port = matched[10];
+
+          var new_server_config = {
+            "name": protocol + username + '@' + host,
+            "host": host,
+            "port": port,
+            "user": username,
+            "password": password,
+            "sftp": (protocol=='sftp://'),
+            "privatekeyfile": "",
+            "remote": "/"
+        };
+        if(self.debug) {
+            console.log("Adding new server by uri handler", new_server_config);
+        }
+
+        self.treeView.addServer(new_server_config);
+      }
   }
 
   consumeElementIcons(service) {

--- a/lib/views/tree-view.js
+++ b/lib/views/tree-view.js
@@ -272,9 +272,14 @@ class TreeView extends ScrollView {
     });
 
     self.servers.forEach((config) => {
+      self.addServer(config);
+    });
+  };
+
+  addServer(config) {
+      const self = this;
       let server = new ServerView(config, self);
       self.list.append(server);
-    });
   };
 
   showInfo() {

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
         "1.0.0": "consumeElementIcons"
       }
     }
+  },
+  "uriHandler" : {
+      "method" : "handleURI"
   }
 }


### PR DESCRIPTION
I've added my request of adding uri handler. With this change it is possible to open ftp/sftp by using uri, like:

atom://ftp-remote-edit/sftp://demo:password@test.rebex.net
or
atom://ftp-remote-edit/ftp://demo:password@test.rebex.net

It is possible to use it with/without username, password and port. Very usefull for example with keepass url field.