### PR TITLE
Fixed allowPendingPaneItems config

### DIFF
--- a/lib/views/file-view.js
+++ b/lib/views/file-view.js
@@ -75,8 +75,9 @@ class FileView extends View {
     // Events
     self.on('click', function (e) {
       e.stopPropagation();
+
       if (atom.config.get('ftp-remote-edit.tree.allowPendingPaneItems')) {
-        self.open(true);
+        //self.open(true);
       } else {
         self.open();
       }


### PR DESCRIPTION
When allowPendingPaneItems is set, click does not perform any action.

Refer to issue #171 