### PR TITLE
Add providers for opening files and getting server config

### DIFF
--- a/lib/ftp-remote-edit.js
+++ b/lib/ftp-remote-edit.js
@@ -14,9 +14,10 @@ import FindDialog from './dialogs/find-dialog.js';
 
 import { $ } from 'atom-space-pen-views';
 import { decrypt, encrypt, checkPasswordExists, checkPassword, setPassword, changePassword } from './helper/secure.js';
-import { basename, trailingslashit } from './helper/format.js';
+import { basename, trailingslashit, normalize } from './helper/format.js';
 import { CompositeDisposable, Disposable, TextEditor } from 'atom';
 
+const Path = require('path');
 const getIconServices = require('./helper/icon.js');
 const atom = global.atom;
 const config = require('./config/config-schema.json');
@@ -144,6 +145,29 @@ class FtpRemoteEdit {
       }
 
       self.treeView.addServer(new_server_config);
+    }
+  }
+
+  openRemoteFile() {
+    const self = this;
+    return (file) => {
+      const selected = self.treeView.list.find('.selected');
+      if (selected.length === 0) return;
+      let root = selected.view().getRoot();
+      let localPath = normalize((root.getLocalPath().replace(root.getPath(), '') + file).replace(/\/+/g, Path.sep), Path.sep);
+      try {
+        let file = self.treeView.getElementByLocalPath(localPath, root, 'file');
+        file.open();
+      } catch (ex) {}
+    }
+  }
+
+  getCurrentServerConfig() {
+    const self = this;
+    return () => {
+      const selected = self.treeView.list.find('.selected');
+      let root = selected.view().getRoot();
+      return root.config
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,18 @@
       }
     }
   },
+  "providedServices": {
+    "ftp-remote.openFile": {
+      "versions": {
+        "0.1.0": "openRemoteFile"
+      }
+    },
+    "ftp-remote.getCurrentServerConfig": {
+      "versions": {
+        "0.1.0": "getCurrentServerConfig"
+      }
+    }
+  },
   "uriHandler": {
     "method": "handleURI",
     "deferActivation": false


### PR DESCRIPTION
I'm in the process of making [Juno](http://junolab.org) play nicer with remote servers (see [here](https://github.com/JunoLab/atom-julia-client/pull/531) for the relevant PR) and it would be nice if there were some small hooks into this package to facilitate integration on our side.

This PR adds 
1. A provider to allow a third-party package to open an arbitrary file on a remote server via `ftp-remote-edit`. This is probably relatively uncontroversial, but the implementation could probably be nicer.
2. A provider that allows a third-party package to get the ssh configuration for the currently selected server in `ftp-remote-edit`. This definitely shouldn't be merged as-is since every package can get e.g. the password or private key file that way. The best way to handle this would probably be to ask the user to confirm explicitly when another package tries to get the server config, I guess. If that's not an option for you I'll just remove this part of the API.