### PR TITLE
More descriptive pane item names

### DIFF
--- a/lib/views/protocol-view.js
+++ b/lib/views/protocol-view.js
@@ -30,7 +30,11 @@ class ProtocolView extends ScrollView {
   };
 
   getTitle() {
-    return "Ftp-Remote-Edit";
+    return "Remote Transfer Log";
+  }
+
+  getIconName() {
+    return "list-unordered";
   }
 
   getURI() {

--- a/lib/views/tree-view.js
+++ b/lib/views/tree-view.js
@@ -55,7 +55,7 @@ class TreeView extends ScrollView {
   };
 
   getTitle() {
-    return "Ftp-Remote-Edit";
+    return "Project (Remote)";
   }
 
   getURI() {
@@ -278,7 +278,7 @@ class TreeView extends ScrollView {
 
   addServer(config) {
     const self = this;
-    
+
     let server = new ServerView(config, self);
     self.list.append(server);
   };

--- a/lib/views/tree-view.js
+++ b/lib/views/tree-view.js
@@ -55,7 +55,7 @@ class TreeView extends ScrollView {
   };
 
   getTitle() {
-    return "Project (Remote)";
+    return "Remote";
   }
 
   getURI() {


### PR DESCRIPTION
This PR changes the pane item names to something a bit more descriptive and adds an icon for the protocol view:

![image](https://user-images.githubusercontent.com/6735977/48977945-9599fd80-f0a4-11e8-98b9-54f3169cd28b.png)
