### PR TITLE
Handleuri decodeURI

### DIFF
--- a/lib/config/server-schema.json
+++ b/lib/config/server-schema.json
@@ -9,5 +9,6 @@
   "sftp": false,
   "privatekeyfile": "",
   "remote": "/",
-  "logon": "credentials"
+  "logon": "credentials",
+  "temp": false
 }

--- a/lib/ftp-remote-edit.js
+++ b/lib/ftp-remote-edit.js
@@ -25,6 +25,7 @@ const server_config = require('./config/server-schema.json');
 
 const atom = global.atom;
 const Path = require('path');
+const DecodeHtml = require('decode-html');
 const FileSystem = require('fs-plus');
 const getIconServices = require('./helper/icon.js');
 const Queue = require('./helper/queue.js');
@@ -168,11 +169,11 @@ class FtpRemoteEdit {
       let matched = regex.exec(parsedUri.path);
 
       let protocol = matched[2];
-      let username = matched[4];
-      let password = matched[7];
-      let host = matched[8];
+      let username = DecodeHtml(matched[4]);
+      let password = DecodeHtml(matched[7]);
+      let host = DecodeHtml(matched[8]);
       let port = matched[10];
-      let path = matched[11] || "/";
+      let path = DecodeHtml(matched[11]) || "/";
 
       let newconfig = JSON.parse(JSON.stringify(server_config));
       newconfig.name = protocol + username + '@' + host;
@@ -182,6 +183,7 @@ class FtpRemoteEdit {
       newconfig.password = password;
       newconfig.sftp = (protocol == 'sftp://');
       newconfig.remote = path;
+      newconfig.temp = true;
 
       if (self.debug) {
         console.log("Adding new server by uri handler", newconfig);

--- a/lib/ftp-remote-edit.js
+++ b/lib/ftp-remote-edit.js
@@ -25,7 +25,6 @@ const server_config = require('./config/server-schema.json');
 
 const atom = global.atom;
 const Path = require('path');
-const DecodeHtml = require('decode-html');
 const FileSystem = require('fs-plus');
 const getIconServices = require('./helper/icon.js');
 const Queue = require('./helper/queue.js');
@@ -169,11 +168,11 @@ class FtpRemoteEdit {
       let matched = regex.exec(parsedUri.path);
 
       let protocol = matched[2];
-      let username = DecodeHtml(matched[4]);
-      let password = DecodeHtml(matched[7]);
-      let host = DecodeHtml(matched[8]);
+      let username = decodeURIComponent(matched[4]);
+      let password = decodeURIComponent(matched[7]);
+      let host = decodeURIComponent(matched[8]);
       let port = matched[10];
-      let path = DecodeHtml(matched[11]) || "/";
+      let path = decodeURIComponent(matched[11]) || "/";
 
       let newconfig = JSON.parse(JSON.stringify(server_config));
       newconfig.name = protocol + username + '@' + host;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "p-queue": "^3.0.0",
     "progress-stream": "^2.0.0",
     "short-hash": "^1.0.0",
-    "ssh2": "^0.8.2"
+    "ssh2": "^0.8.2",
+    "decode-html": "^2.0.0"
   },
   "consumedServices": {
     "file-icons.element-icons": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "p-queue": "^3.0.0",
     "progress-stream": "^2.0.0",
     "short-hash": "^1.0.0",
-    "ssh2": "^0.8.2",
-    "decode-html": "^2.0.0"
+    "ssh2": "^0.8.2"
   },
   "consumedServices": {
     "file-icons.element-icons": {


### PR DESCRIPTION
I found out that when we use html entites in password or login (mostly cases ftp login is e-mail), html entites won't be translated to chars. It will repair it, so we can use links like:

sftp://test%40test.pl:lastcharofpasswordisatandinuserwehaveone%40@8.8.8.8:5435

Also, added 'temp' for servers for future use (for example - allowing adding them from current view to config).