### PR TITLE
Don't allow to create temp duplicates on server list

### DIFF
--- a/lib/helper/helper.js
+++ b/lib/helper/helper.js
@@ -35,6 +35,10 @@ export const showMessage = (msg, type = 'info') => {
     atom.notifications.addInfo('Ftp-Remote-Edit', {
       description: msg
     });
+  } else if (type === 'warning') {
+    atom.notifications.addWarning('Ftp-Remote-Edit', {
+      description: msg
+    });
   } else {
     atom.notifications.addError('Ftp-Remote-Edit', {
       description: msg,

--- a/lib/views/tree-view.js
+++ b/lib/views/tree-view.js
@@ -3,7 +3,7 @@
 import { $, ScrollView } from 'atom-space-pen-views';
 import { basename, dirname, leadingslashit, trailingslashit, unleadingslashit, untrailingslashit, normalize, cleanJsonString } from './../helper/format.js';
 import { decrypt } from './../helper/secure.js';
-import { resetIgnoredPatterns, resetIgnoredFinderPatterns, permissionsToRights } from './../helper/helper.js';
+import { showMessage, resetIgnoredPatterns, resetIgnoredFinderPatterns, permissionsToRights } from './../helper/helper.js';
 import { throwErrorIssue44 } from './../helper/issue.js';
 import ServerView from './server-view.js';
 import FolderView from './folder-view.js';
@@ -225,6 +225,14 @@ class TreeView extends ScrollView {
     const self = this;
 
     let server = new ServerView(config);
+
+    if (server.config.temp) {
+      let servers = self.list.children('#' + server.getId());
+      if (servers.length > 0) {
+        showMessage('Server you are trying to add is already on the list!', 'warning');
+        return false;
+      }
+    }
 
     // Events
     server.getConnector().on('log', (msg) => {


### PR DESCRIPTION
Like on topic - blocks to add same server twice. When i work, I often run it from handler - and have same server for few times, and have a really mess after week of work ;)