### PR TITLE
Fix #352: Permission denied when creating a folder

### DIFF
--- a/lib/connectors/connector.js
+++ b/lib/connectors/connector.js
@@ -192,38 +192,39 @@ export default class Connector extends EventEmitter {
     if (!directory) directory = '/';
 
     // Walk recursive through directory tree and create non existing directories
+    // Skip creating dir in path on fail
+    let next = () => {
+      if (remotePaths.length > 0) {
+        return self.createDirectoryStructure(client, remotePaths).then(() => {
+          return Promise.resolve(path.trim());
+        }).catch((error) => {
+          return Promise.reject(error);
+        });
+      } else {
+        return Promise.resolve(path.trim());
+      }
+    };
+
     return client.list(directory).then((list) => {
       let dir = list.find((item) => {
         return item.name == path.split('/').slice(-1)[0];
       });
 
       if (dir) {
-        if (remotePaths.length > 0) {
-          return self.createDirectoryStructure(client, remotePaths).then(() => {
-            return Promise.resolve(path.trim());
-          }).catch((error) => {
-            return Promise.reject(error);
-          });
-        } else {
-          return Promise.resolve(path.trim());
-        }
+        return next();
       } else {
         return client.mkdir(path.trim()).then(() => {
-          if (remotePaths.length > 0) {
-            return self.createDirectoryStructure(client, remotePaths).then(() => {
-              return Promise.resolve(path.trim());
-            }).catch((error) => {
-              return Promise.reject(error);
-            });
-          } else {
-            return Promise.resolve(path.trim());
-          }
+          return next();
         }).catch((error) => {
           return Promise.reject(error);
         });
       }
     }).catch((error) => {
-      return Promise.reject(error);
+      if (remotePaths.length > 0) {
+        return next();
+      } else {
+        return Promise.reject(error);
+      }
     });
   }
 


### PR DESCRIPTION
When SFTP does not have permission to list a folder, but does have access to subsequent folders, which is very often the case (e.g. mkdir /home/<user>/mynewfolder but no permission to ls /home), creating the folder fails. This change keeps trying to create a the folder in the next folder even if it doesn't have access to the current folder.