### PR TITLE
Fixes undefined variables (tmp, pathToCopy, pane...)

### DIFF
--- a/lib/ftp-remote-edit.js
+++ b/lib/ftp-remote-edit.js
@@ -1902,11 +1902,7 @@ class FtpRemoteEdit {
     if (selected.length === 0) return;
 
     let element = selected.view();
-    if (element.is('.directory')) {
-      pathToCopy = element.getPath(true);
-    } else {
-      pathToCopy = element.getPath(true) + element.name;
-    }
+    let pathToCopy = element.getPath(true) + (element.is('.directory') ? "" : element.name);
     atom.clipboard.write(pathToCopy)
   }
 

--- a/lib/helper/finder-items-cache.js
+++ b/lib/helper/finder-items-cache.js
@@ -141,7 +141,7 @@ class FinderItemsCache extends EventEmitter {
     try {
       if (FileSystem.existsSync(file)) {
         let tmp = FileSystem.readFileSync(file);
-        cache = JSON.parse(tmp);
+        let cache = JSON.parse(tmp);
         self.paths = cache.paths;
         self.items = cache.items;
         return true;

--- a/lib/helper/helper.js
+++ b/lib/helper/helper.js
@@ -393,7 +393,7 @@ export const getTextEditor = (pathOnFileSystem, activate = false) => {
   });
 
   if (activate && foundEditor) {
-    pane = atom.workspace.paneForItem(foundEditor);
+    let pane = atom.workspace.paneForItem(foundEditor);
     if (pane) pane.activateItem(foundEditor);
   }
 

--- a/lib/views/tree-view.js
+++ b/lib/views/tree-view.js
@@ -609,7 +609,7 @@ class TreeView extends ScrollView {
     let next = current.find('.entries .entry:visible');
 
     if (!next.length) {
-      tmp = current;
+      let tmp = current;
 
       // Workaround skip after 10
       let counter = 1;


### PR DESCRIPTION
Supersedes #455 because it handles more than just `tmp`.

Closes #454, closes #450, closes #463, and closes #464.